### PR TITLE
delete layout engine for d2

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -19,7 +19,6 @@ Currently, KubeBrowser uses a unique OIDC configuration for all the Kubeconfig
 vars: {
   d2-config: {
     theme-id: 105
-    layout-engine: tala
   }
 }
 


### PR DESCRIPTION
Because kroki (hence the vitepress plugin) cannot render using proprietary tala engine from d2 company